### PR TITLE
Improved animation tick performance

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
             outline: 0;
             list-style: none;
             font-size: 16px;
-            font-family: ‘Helvetica Neue’, Helvetica, Arial, sans-serif;
+            font-family: ï¿½Helvetica Neueï¿½, Helvetica, Arial, sans-serif;
         }
 
 
@@ -837,7 +837,7 @@
             }
         }
 
-        
+
 
         function GenerateRedraw(subImg) {
 
@@ -896,7 +896,7 @@
                 }
             }
 
-            
+
 
         }
 
@@ -1332,7 +1332,7 @@
             text = text.trim().toLowerCase();
             var c, coords;
 
-            
+
 
             if (text.indexOf('rgb') == 0) {
                 var parts = text.replace('rgb(', '').split(')');
@@ -1628,7 +1628,7 @@
                             drawPts.splice(idx, 1);
                         }
                     }
-                    
+
                 }
 
             },
@@ -1653,7 +1653,7 @@
 
             //        tempList.splice(rndIdx, 1);
             //    }
-                
+
 
             //}
         ]
@@ -1693,12 +1693,10 @@
                     pendingDraws[i].Delay--;
 
                 }
-                
+
             }
 
-            for (var i = removeList.length - 1; i >= 0; i--) {
-                pendingDraws.splice(removeList[i], 1);
-            }
+            pendingDraws = pendingDraws.filter((_, i) => !removeList.includes(i));
 
             removeList = [];
 
@@ -1784,9 +1782,7 @@
 
             }
 
-            for (var i = removeList.length - 1; i >= 0; i--) {
-                pendingAnimations.splice(removeList[i], 1);
-            }
+            pendingAnimations = pendingAnimations.filter((_, i) => !removeList.includes(i));
 
             requestAnimationFrame(AnimationTick);
         }

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
             outline: 0;
             list-style: none;
             font-size: 16px;
-            font-family: �Helvetica Neue�, Helvetica, Arial, sans-serif;
+            font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
         }
 
 


### PR DESCRIPTION
Significantly faster removal of "draws" and "animations" when there are large quanitites of either on a single frame.
Especially useful for the redraw event with large history.

As discussed in Twitch and Discord, sometimes the redraw starts off extremely slowly and speeds-up as the redraw continues. It was found the lag was heavily dominated by a slow execution of the `AnimationTick` on callback, which was then isolated to portion where the drawn "draws" or the drawn "animations" were removed.

Unfortunately, the way `Array#splice` works meant that sometimes the `pendingDraws` and `pendingAnimations` were shrunk thousands of times per animation frame. By switching to a single re-assignment, we eliminate a large amount of the array manipulation, even though we now search `removeList` potentially thousands of times. This is most likely due to the fact that each time an item is removed, the engine (probably)* has to change the index of every single element afterwards, which is typically the majority of the animation array.

`Array#includes` isn't supported in Internet Explorer. But neither are arrow functions. If IE support is desired, we can simply change
`removeItems.includes(i)`
to
`removeItems.some(function(remove) { return remove === i; })`

New execution takes much less time and maintains a respectable frame rate. Inevitably, as the draw size grows, it will slow down, but even the rate of change should be less than before.

There exists a potential breaking change if anything depends on reference access to `pendingDraws` or `pendingAnimations`, though I didn't see any in the code.

*I'm not actually sure if this is what the engine does, but it wouldn't surprise me. At any rate, doing a lot of them is **very** slow.