### PR TITLE
Partially addresses time difference between `!redraw` and redrawing

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
             outline: 0;
             list-style: none;
             font-size: 16px;
-            font-family: ‘Helvetica Neue’, Helvetica, Arial, sans-serif;
+            font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
         }
 
 
@@ -837,13 +837,13 @@
             }
         }
 
-        
+
 
         function GenerateRedraw(subImg) {
 
             var duration = 60 * 10;
 
-            sceneHistory.sort((a, b) => { return parseInt(a.Timestamp, 10) > parseInt(b.Timestamp) ? 1 : -1; });
+            sceneHistory.sort((a, b) => a.Timestamp - b.Timestamp);
 
            // var gridStatus = Create2DArray(config.GridWidth);
 
@@ -896,7 +896,7 @@
                 }
             }
 
-            
+
 
         }
 
@@ -1332,7 +1332,7 @@
             text = text.trim().toLowerCase();
             var c, coords;
 
-            
+
 
             if (text.indexOf('rgb') == 0) {
                 var parts = text.replace('rgb(', '').split(')');
@@ -1628,7 +1628,7 @@
                             drawPts.splice(idx, 1);
                         }
                     }
-                    
+
                 }
 
             },
@@ -1653,7 +1653,7 @@
 
             //        tempList.splice(rndIdx, 1);
             //    }
-                
+
 
             //}
         ]
@@ -1693,7 +1693,7 @@
                     pendingDraws[i].Delay--;
 
                 }
-                
+
             }
 
             for (var i = removeList.length - 1; i >= 0; i--) {


### PR DESCRIPTION
As addressed on Twitch and Discord, when the `!redraw` commands occurs, sometimes there is a very significant delay before the redraw actually starts. I'm not certain that this fix will address all of that, but it should address a major pain point, especially over larger data sets.

Analysis of `GenerateRedraw()` found that the vast majority of the time spent in the function was sorting the history (tested with history ~100k items), taking ~2000ms. Inspecting the sort, it seemed that the ternary wasn't required, simple subtraction would be faster, but changing that changed the run time negligibly (down to ~1800ms). Inspecting the individual `sceneHistory` items revealed the `Timestamp` property to be an integer, so dropping the unnecessary, explicit, integer conversion reduced the sort time down to around ~110ms.

Overall, I expect making this change to result in redraws firing 15 to 20 times faster than before.